### PR TITLE
Feature/copy from to bytes

### DIFF
--- a/src/stdlib/memcpy.mbt
+++ b/src/stdlib/memcpy.mbt
@@ -4,3 +4,26 @@ pub extern "c" fn memcpy(
   src : @c.Pointer[Byte],
   len : UInt64,
 ) -> Unit = "moonbit_c_memcpy"
+
+///|
+fn bytes_to_c_ptr(bytes : Bytes) -> @c.Pointer[Byte] = "%identity"
+
+///|
+pub fn memcpy_from_bytes(
+  dest : @c.Pointer[Byte],
+  source : Bytes,
+  length : UInt64,
+) -> Unit {
+  let src_ptr = bytes_to_c_ptr(source)
+  memcpy(dest, src_ptr, length)
+}
+
+///|
+pub fn memcpy_to_bytes(
+  dest : Bytes,
+  source : @c.Pointer[Byte],
+  length : UInt64,
+) -> Unit {
+  let dest_ptr = bytes_to_c_ptr(dest)
+  memcpy(dest_ptr, source, length)
+}


### PR DESCRIPTION
This PR adds `memcpy_from_bytes()` and `mem_copy_to_bytes` as discussed in https://github.com/tonyfettes/c.mbt/pull/7#issuecomment-3288545084.

I have added these functions to `@stdlib` package rather than as methods to `Pointer` struct. This is to get around the issue of circular dependency - `stdlib -> c -> stdlib`. 